### PR TITLE
Safer version test for photutils dev versions

### DIFF
--- a/statmorph/statmorph.py
+++ b/statmorph/statmorph.py
@@ -391,7 +391,7 @@ class SourceMorphology(object):
             self._segmap = photutils.SegmentationImage(self._segmap)
 
         # Check sanity of input data
-        if float(photutils.__version__) < 0.5:
+        if photutils.__version__ < '0.5':
             self._segmap.check_label(self.label)
         else:
             self._segmap.check_labels([self.label])


### PR DESCRIPTION
This is a quick fix to the check on the `photutils` module version, which can be a `string` that doesn't convert to a `float`.   String tests with `>`, `<`, etc. work for well-formed version numbers, for example:

```python
>>> import photutils             
>>> msg = 'Version {0} is > 0.5 .... {1}'                                           
>>> print(msg.format(photutils.__version__, photutils.__version__ > '0.5'))
Version 0.7.dev3423 is > 0.5 .... True
```