### PR TITLE
Update tutorial notebook for photutils 0.7 deprecation

### DIFF
--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "threshold = photutils.detect_threshold(image, snr=1.5)\n",
+    "threshold = photutils.detect_threshold(image, 1.5)\n",
     "npixels = 5  # minimum number of connected pixels\n",
     "segm = photutils.detect_sources(image, threshold, npixels)"
    ]


### PR DESCRIPTION
In `photutils 0.7`, the `detect_threshold` `snr` keyword was renamed to `nsigma`.  The `snr` keyword was deprecated in 0.7 and will be removed in 0.8.  To work will all versions of photutils (and not have version-checking boilerplate in the notebook), I simply passed the value by position (i.e. with out the keyword name).  I also added more robust checks for the `photutils` version.