### PR TITLE
Update the _sersic_model() function to properly handle the fitting ranges of the x, y center.

### DIFF
--- a/statmorph/statmorph.py
+++ b/statmorph/statmorph.py
@@ -2612,6 +2612,14 @@ class SourceMorphology(object):
         self._sersic_model_args['x_0'] -= self.xmin_stamp
         self._sersic_model_args['y_0'] -= self.ymin_stamp
 
+        # ..as well as the bounds for the origin
+        if 'x_0' in self._sersic_model_args['bounds']:
+            self._sersic_model_args['bounds']['x_0'][0] -= self.xmin_stamp
+            self._sersic_model_args['bounds']['x_0'][1] -= self.xmin_stamp
+        if 'y_0' in self._sersic_model_args['bounds']:
+            self._sersic_model_args['bounds']['y_0'][0] -= self.ymin_stamp
+            self._sersic_model_args['bounds']['y_0'][1] -= self.ymin_stamp
+
         # For readability
         guess_r_eff = self._sersic_model_args['r_eff']
         guess_center = np.array([self._sersic_model_args['x_0'],


### PR DESCRIPTION
When I give the constraints for the x, y center for the 2D Sérsic fitting, these ranges are not handled properly when creating the stamp image. 
It seems that the fitting ranges are not converted to the frame of the stamp image, while the initial guess for the center position is converted well.